### PR TITLE
Repaired broken jQuery selectors for recruiting service

### DIFF
--- a/app/services/recruiting.service.js
+++ b/app/services/recruiting.service.js
@@ -1,128 +1,141 @@
 const rp = require('request-promise');
 const cheerio = require('cheerio');
 
-exports.getPlayerRankings = ({year, page = 1, group = "HighSchool", position = null, state = null}) => {
-    const baseUrl = `http://247sports.com/Season/${year}-Football/CompositeRecruitRankings`;
-    const queryParams = {
-        InstitutionGroup: group,
-        Page: page,
-        Position: position,
-        State: state
-    };
+exports.getPlayerRankings = ({ year, page = 1, group = "HighSchool", position = null, state = null }) => {
+  const baseUrl = `http://247sports.com/Season/${year}-Football/CompositeRecruitRankings`;
+  const queryParams = {
+    InstitutionGroup: group,
+    Page: page,
+    Position: position,
+    State: state
+  };
 
-    return rp({
-            url: baseUrl,
-            qs: queryParams,
-            headers: {
-                'User-Agent': 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36'
-            }
-        })
-        .then((body) => {
-            let $ = cheerio.load(body);
+  return rp({
+    url: baseUrl,
+    qs: queryParams,
+    headers: {
+      'User-Agent': 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36'
+    }
+  })
+    .then((body) => {
+      let $ = cheerio.load(body);
 
-            let players = [];
+      let players = [];
 
-            $("ul.content-list > li:not([class])").each(function (index) {
-                let html = $(this);
+      // Couldn't grab the rank correctly with JQuery so it's manually calculated
+      let rank = 1 + 50 * (page - 1);
 
-                let player = {
-                    ranking: html.find(".primary").text().trim(),
-                    name: html.find(".name a").text().trim(),
-                    highSchool: html.find("span.meta").text().trim(),
-                    position: html.find(".position").text().trim(),
-                    height: html.find(".height").text().trim(),
-                    weight: html.find(".weight").text().trim(),
-                    stars: html.find(".rating > .yellow").length,
-                    rating: html.find(".rating").text().trim().trim(),
-                    college: html.find(".right-content .jsonly").prop("title") || "uncommitted"
-                }
+      $('ul.rankings-page__list > li.rankings-page__list-item:not(.rankings-page__list-item--header)').each(function (index) {
+        let html = $(this);
 
-                players.push(player);
-            });
+        let metrics = html.find('.metrics').text().split('/');
 
-            return players;
-        })
-        .error((error) => {
-            console.log(error);
-        });
+        let player = {
+          ranking: rank,
+          name: html.find('.rankings-page__name-link').text().trim(),
+          highSchool: html.find('span.meta').text().trim(),
+          position: html.find('.position').text().trim(),
+          height: metrics[0],
+          weight: metrics[1],
+          stars: html.find('.rankings-page__star-and-score > .yellow').length,
+          rating: html.find('.score').text().trim().trim(),
+          college: html.find('.img-link > img').attr('title') || 'uncommitted'
+        };
+
+        players.push(player);
+        rank++;
+      });
+
+      return players;
+    })
+    .error((error) => {
+      console.log(error);
+    });
 };
 
 exports.getSchoolRankings = (year, page = 1) => {
-    const baseUrl = `http://247sports.com/Season/${year}-Football/CompositeTeamRankings`;
+  const baseUrl = `http://247sports.com/Season/${year}-Football/CompositeTeamRankings`;
 
-    return rp({
-            url: baseUrl,
-            qs: {
-                Page: page
-            },
-            headers: {
-                'User-Agent': 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36'
-            }
-        })
-        .then((body) => {
-            let $ = cheerio.load(body);
-            let schools = [];
+  return rp({
+    url: baseUrl,
+    qs: {
+      Page: page
+    },
+    headers: {
+      'User-Agent': 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36'
+    }
+  })
+    .then((body) => {
+      let $ = cheerio.load(body);
+      let schools = [];
 
-            $("ul.team-rankings-index > li:not([class])").each(function (index) {
-                let html = $(this);
+      $('.rankings-page__list-item').each(function (index) {
+        let html = $(this);
 
-                let school = {
-                    rank: html.find(".rank .primary").text().trim(),
-                    school: html.find(".name").text().trim(),
-                    totalCommits: html.find(".metrics-list a").text().replace('Total: ', '').trim(),
-                    fiveStars: $(html.find(".metrics-list li")[1]).text().replace("5: ", "").trim(),
-                    fourStars: $(html.find(".metrics-list li")[2]).text().replace("4: ", "").trim(),
-                    threeStars: $(html.find(".metrics-list li")[3]).text().replace("3: ", "").trim(),
-                    averageRating: $(html.find(".metrics-list li")[4]).text().replace("Avg: ", "").trim(),
-                    points: html.find('.number').text().trim()
-                }
+        let school = {
+          rank: html.find('.rank-column .primary').text().trim(),
+          school: html.find('.rankings-page__name-link').text().trim(),
+          totalCommits: html.find('.total a').text().trim(),
+          fiveStars: $(html.find('ul.star-commits-list > li > div')[0]).text().replace('5: ', '').trim(),
+          fourStars: $(html.find('ul.star-commits-list > li > div')[1]).text().replace('4: ', '').trim(),
+          threeStars: $(html.find('ul.star-commits-list > li > div')[2]).text().replace('3: ', '').trim(),
+          averageRating: html.find('.avg').text().trim(),
+          points: html.find('.number').text().trim()
+        };
 
-                schools.push(school);
-            });
+        schools.push(school);
+      });
 
-            return schools;
-        })
-        .error((error) => {
-            console.log(error);
-        });
+      return schools;
+    })
+    .error((error) => {
+      console.log(error);
+    });
 };
 
 exports.getSchoolCommits = (school, year) => {
-    const baseUrl = `http://${school}.247sports.com/Season/${year}-Football/Commits`;
+  const baseUrl = `http://${school}.247sports.com/Season/${year}-Football/Commits`;
 
-    return rp({
-            url: baseUrl,
-            headers: {
-                'User-Agent': 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36'
-            }
-        })
-        .then((body) => {
-            let $ = cheerio.load(body);
+  return rp({
+    url: baseUrl,
+    headers: {
+      'User-Agent': 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36'
+    }
+  })
+    .then((body) => {
+      let $ = cheerio.load(body);
 
-            let players = [];
+      let players = [];
 
-            $(".ri-list > li:not([class])").each(function (index) {
-                let html = $(this);
+      $('.ri-page__list-item').each(function (index) {
+        let html = $(this);
 
-                let player = {
-                    name: html.find(".list-data a.name").text().trim(),
-                    highSchool: html.find(".list-data span.meta").text().trim(),
-                    position: $(html.find(".metrics-list li")[0]).text().trim(),
-                    height: $(html.find(".metrics-list li")[1]).text().trim(),
-                    weight: $(html.find(".metrics-list li")[2]).text().trim(),
-                    stars: html.find(".list-data .rating .star > .icon-starsolid.yellow").length,
-                    rating: html.find(".list-data .rating .score").clone().children().remove().end().text().trim(),
-                    nationalRank: html.find(".list-data .natrank").first().text().trim(),
-                    stateRank: html.find(".list-data .sttrank").first().text().trim(),
-                    positionRank: html.find(".list-data .posrank").first().text().trim()
-                }
+        let metrics = html.find('.metrics').text().split('/');
 
-                players.push(player);
-            });
+        let player = {
+          name: html.find('.ri-page__name-link').text().trim(),
+          highSchool: html.find('span.meta').text().trim(),
+          position: $(html.find('.position')).text().trim(),
+          height: metrics[0],
+          weight: metrics[1],
+          stars: html.find('.ri-page__star-and-score .yellow').length,
+          rating: html.find('span.score').clone().children().remove().end().text().trim(),
+          nationalRank: html.find('.natrank').first().text().trim(),
+          stateRank: html.find('.sttrank').first().text().trim(),
+          positionRank: html.find('.posrank').first().text().trim()
+        };
 
-            return players;
-        })
-        .error((error) => {
-            console.log(error);
-        });
+        players.push(player);
+      });
+
+      // Some empty player objects were being created.  This removes them
+      const result = players.filter(
+        player => player.name !== '' && player.rating !== ''
+      );
+
+      return result;
+    })
+    .error((error) => {
+      console.log(error);
+    });
 };


### PR DESCRIPTION
It looks like 24/7 changed their css up for all of their recruiting pages, which broke all of the recruiting services for cfb-data.  I fixed and tested all of the recruiting services locally, but figured I should push the changes so others can use them.