### PR TITLE
fixing schedule's groups to group

### DIFF
--- a/app/services/schedule.service.js
+++ b/app/services/schedule.service.js
@@ -10,7 +10,7 @@ const getSchedule = ({
     const queryParams = {
         dates: year,
         week,
-        groups,
+        group: groups,
         seasontype: seasontype,
         xhr: 1
     };


### PR DESCRIPTION
this was broken in espn's latest schedule api

I tested all other instances of 'groups' for the other services
they all seem fine.